### PR TITLE
solving abnormal classfication loss by adding background class

### DIFF
--- a/train.py
+++ b/train.py
@@ -121,7 +121,7 @@ def train(opt):
                                                         Resizer(input_sizes[opt.compound_coef])]))
     val_generator = DataLoader(val_set, **val_params)
 
-    model = EfficientDetBackbone(num_classes=len(params.obj_list), compound_coef=opt.compound_coef,
+    model = EfficientDetBackbone(num_classes=len(params.obj_list)+1, compound_coef=opt.compound_coef,
                                  ratios=eval(params.anchors_ratios), scales=eval(params.anchors_scales))
 
     # load last weights


### PR DESCRIPTION
[#54](https://github.com/zylo117/Yet-Another-EfficientDet-Pytorch/issues/54)
[#58](https://github.com/zylo117/Yet-Another-EfficientDet-Pytorch/issues/58)

Must add background class when calculating class loss in https://github.com/zylo117/Yet-Another-EfficientDet-Pytorch/blob/96570fbed3ae5c2a8772a91feb27685e4ce32bf9/efficientdet/loss.py#L94

Other implemention of Focal loss for reference, they add background class as well.
https://github.com/open-mmlab/mmdetection/blob/25ede58af6072ea8089af7b42cbb418a3b6991e9/configs/retinanet_r50_fpn_1x.py#L22