### PR TITLE
setting numpy threads environment variables

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,9 @@
 
 import datetime
 import os
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
 import argparse
 import traceback
 


### PR DESCRIPTION
for multi-process pre-processing, if the model process data using numpy with multi-thread, it may cause cpu overheads, resulting in a multi-core computing speed that slower than a single core. It could be solved by setting numpy threads environment variables.